### PR TITLE
Allows customization of taiga-front port mapping

### DIFF
--- a/images/3.3/alpine/.env
+++ b/images/3.3/alpine/.env
@@ -9,6 +9,8 @@ HOSTNAME=localhost
 # Adapt to your production domain and use a reverse proxy
 #HOSTNAME=taiga.company.com
 
+PORT=80
+
 TAIGA_DB_PWD=somethingverysecure,changethis!
 
 

--- a/images/3.3/alpine/docker-compose.yml
+++ b/images/3.3/alpine/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=False
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       # Secret key for cryptographic signing
@@ -115,8 +115,9 @@ services:
       # To enable async mode, uncomment the following lines:
       #- taiga_redis
     ports:
-      - 80:80
-      - 443:443
+      # If using SSL, uncomment 443 and comment out 80
+      - ${PORT}:80
+      #- ${PORT}:443
     volumes:
       # Media and uploads directory. Required for NGinx
       - /srv/taiga/back/media:/usr/src/taiga-back/media:ro
@@ -127,7 +128,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=True
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       #- TAIGA_BACKEND_SSL=True

--- a/images/3.4/alpine/.env
+++ b/images/3.4/alpine/.env
@@ -9,6 +9,8 @@ HOSTNAME=localhost
 # Adapt to your production domain and use a reverse proxy
 #HOSTNAME=taiga.company.com
 
+PORT=80
+
 TAIGA_DB_PWD=somethingverysecure,changethis!
 
 

--- a/images/3.4/alpine/docker-compose.yml
+++ b/images/3.4/alpine/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=False
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       # Secret key for cryptographic signing
@@ -115,8 +115,9 @@ services:
       # To enable async mode, uncomment the following lines:
       #- taiga_redis
     ports:
-      - 80:80
-      - 443:443
+      # If using SSL, uncomment 443 and comment out 80
+      - ${PORT}:80
+      #- ${PORT}:443
     volumes:
       # Media and uploads directory. Required for NGinx
       - /srv/taiga/back/media:/usr/src/taiga-back/media:ro
@@ -127,7 +128,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=True
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       #- TAIGA_BACKEND_SSL=True

--- a/images/4.0/alpine/.env
+++ b/images/4.0/alpine/.env
@@ -9,6 +9,8 @@ HOSTNAME=localhost
 # Adapt to your production domain and use a reverse proxy
 #HOSTNAME=taiga.company.com
 
+PORT=80
+
 TAIGA_DB_PWD=somethingverysecure,changethis!
 
 

--- a/images/4.0/alpine/docker-compose.yml
+++ b/images/4.0/alpine/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=False
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       # Secret key for cryptographic signing
@@ -115,8 +115,9 @@ services:
       # To enable async mode, uncomment the following lines:
       #- taiga_redis
     ports:
-      - 80:80
-      - 443:443
+      # If using SSL, uncomment 443 and comment out 80
+      - ${PORT}:80
+      #- ${PORT}:443
     volumes:
       # Media and uploads directory. Required for NGinx
       - /srv/taiga/back/media:/usr/src/taiga-back/media:ro
@@ -127,7 +128,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=True
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       #- TAIGA_BACKEND_SSL=True

--- a/images/4.1/alpine/.env
+++ b/images/4.1/alpine/.env
@@ -9,6 +9,8 @@ HOSTNAME=localhost
 # Adapt to your production domain and use a reverse proxy
 #HOSTNAME=taiga.company.com
 
+PORT=80
+
 TAIGA_DB_PWD=somethingverysecure,changethis!
 
 

--- a/images/4.1/alpine/docker-compose.yml
+++ b/images/4.1/alpine/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=False
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       # Secret key for cryptographic signing
@@ -115,8 +115,9 @@ services:
       # To enable async mode, uncomment the following lines:
       #- taiga_redis
     ports:
-      - 80:80
-      - 443:443
+      # If using SSL, uncomment 443 and comment out 80
+      - ${PORT}:80
+      #- ${PORT}:443
     volumes:
       # Media and uploads directory. Required for NGinx
       - /srv/taiga/back/media:/usr/src/taiga-back/media:ro
@@ -127,7 +128,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=True
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       #- TAIGA_BACKEND_SSL=True

--- a/images/4.2/alpine/.env
+++ b/images/4.2/alpine/.env
@@ -9,6 +9,8 @@ HOSTNAME=localhost
 # Adapt to your production domain and use a reverse proxy
 #HOSTNAME=taiga.company.com
 
+PORT=80
+
 TAIGA_DB_PWD=somethingverysecure,changethis!
 
 

--- a/images/4.2/alpine/docker-compose.yml
+++ b/images/4.2/alpine/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=False
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       # Secret key for cryptographic signing
@@ -115,8 +115,9 @@ services:
       # To enable async mode, uncomment the following lines:
       #- taiga_redis
     ports:
-      - 80:80
-      - 443:443
+      # If using SSL, uncomment 443 and comment out 80
+      - ${PORT}:80
+      #- ${PORT}:443
     volumes:
       # Media and uploads directory. Required for NGinx
       - /srv/taiga/back/media:/usr/src/taiga-back/media:ro
@@ -127,7 +128,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=True
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       #- TAIGA_BACKEND_SSL=True

--- a/images/5.0/alpine/.env
+++ b/images/5.0/alpine/.env
@@ -9,6 +9,8 @@ HOSTNAME=localhost
 # Adapt to your production domain and use a reverse proxy
 #HOSTNAME=taiga.company.com
 
+PORT=80
+
 TAIGA_DB_PWD=somethingverysecure,changethis!
 
 

--- a/images/5.0/alpine/docker-compose.yml
+++ b/images/5.0/alpine/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=False
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       # Secret key for cryptographic signing
@@ -115,8 +115,9 @@ services:
       # To enable async mode, uncomment the following lines:
       #- taiga_redis
     ports:
-      - 80:80
-      - 443:443
+      # If using SSL, uncomment 443 and comment out 80
+      - ${PORT}:80
+      #- ${PORT}:443
     volumes:
       # Media and uploads directory. Required for NGinx
       - /srv/taiga/back/media:/usr/src/taiga-back/media:ro
@@ -127,7 +128,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=True
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       #- TAIGA_BACKEND_SSL=True

--- a/template/.env
+++ b/template/.env
@@ -9,6 +9,8 @@ HOSTNAME=localhost
 # Adapt to your production domain and use a reverse proxy
 #HOSTNAME=taiga.company.com
 
+PORT=80
+
 TAIGA_DB_PWD=somethingverysecure,changethis!
 
 

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=False
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       # Secret key for cryptographic signing
@@ -115,8 +115,9 @@ services:
       # To enable async mode, uncomment the following lines:
       #- taiga_redis
     ports:
-      - 80:80
-      - 443:443
+      # If using SSL, uncomment 443 and comment out 80
+      - ${PORT}:80
+      #- ${PORT}:443
     volumes:
       # Media and uploads directory. Required for NGinx
       - /srv/taiga/back/media:/usr/src/taiga-back/media:ro
@@ -127,7 +128,7 @@ services:
       - /etc/timezone:/etc/timezone:ro
     environment:
       # Your hostname (REQUIRED)
-      - TAIGA_HOSTNAME=${HOSTNAME}
+      - TAIGA_HOSTNAME=${HOSTNAME}:${PORT}
       #- TAIGA_SSL=True
       #- TAIGA_SSL_BY_REVERSE_PROXY=True
       #- TAIGA_BACKEND_SSL=True


### PR DESCRIPTION
If the user simply changed the port mapping from 80:80 to e.g. 8008:80, the frontend application would stop to function as all requests would be directed to `HOSTNAME` (without any port). This requires the user to append the port on the `HOSTNAME` and it is not obvious for someone that doesn't know how Angular and similar frameworks work.

This patch makes the PORT a variable that is replaced properly on the compose file, allowing the user to change the port by changing the `.env`.