### PR TITLE
RabbitMQ vhost configuration variables (part 3/3)

### DIFF
--- a/images/3.3/alpine/docker-compose.yml
+++ b/images/3.3/alpine/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - TAIGA_EVENTS_ENABLED=True
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       # Async settings
@@ -188,6 +189,7 @@ services:
     environment:
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       - TAIGA_EVENTS_SECRET=${TAIGA_SECRET}

--- a/images/3.4/alpine/docker-compose.yml
+++ b/images/3.4/alpine/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - TAIGA_EVENTS_ENABLED=True
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       # Async settings
@@ -188,6 +189,7 @@ services:
     environment:
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       - TAIGA_EVENTS_SECRET=${TAIGA_SECRET}

--- a/images/4.0/alpine/docker-compose.yml
+++ b/images/4.0/alpine/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - TAIGA_EVENTS_ENABLED=True
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       # Async settings
@@ -188,6 +189,7 @@ services:
     environment:
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       - TAIGA_EVENTS_SECRET=${TAIGA_SECRET}

--- a/images/4.1/alpine/docker-compose.yml
+++ b/images/4.1/alpine/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - TAIGA_EVENTS_ENABLED=True
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       # Async settings
@@ -188,6 +189,7 @@ services:
     environment:
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       - TAIGA_EVENTS_SECRET=${TAIGA_SECRET}

--- a/images/4.2/alpine/docker-compose.yml
+++ b/images/4.2/alpine/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - TAIGA_EVENTS_ENABLED=True
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       # Async settings
@@ -188,6 +189,7 @@ services:
     environment:
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       - TAIGA_EVENTS_SECRET=${TAIGA_SECRET}

--- a/images/5.0/alpine/docker-compose.yml
+++ b/images/5.0/alpine/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - TAIGA_EVENTS_ENABLED=True
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       # Async settings
@@ -188,6 +189,7 @@ services:
     environment:
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       - TAIGA_EVENTS_SECRET=${TAIGA_SECRET}

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - TAIGA_EVENTS_ENABLED=True
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       # Async settings
@@ -188,6 +189,7 @@ services:
     environment:
       - RABBIT_USER=${TAIGA_RABBIT_USER}
       - RABBIT_PASSWORD=${TAIGA_RABBIT_PASSWORD}
+      - RABBIT_VHOST='/'
       - RABBIT_HOST=taiga_rabbit
       - RABBIT_PORT=5672
       - TAIGA_EVENTS_SECRET=${TAIGA_SECRET}


### PR DESCRIPTION
In a larger docker deployment, RabbitMQ might be used by more applications than Taiga. Separation then happens using RabbitMQ vhosts. This patch changes docker-compose to define environment variable for the changes made to Monogramm/docker-taiga-back-base and Monogramm/docker-taiga-events.

Respective pull requests are being made to Monogramm/docker-taiga-back-base#20 and Monogramm/docker-taiga-events#3